### PR TITLE
Improve currency state persistence

### DIFF
--- a/client/src/components/CurrencySwitcher.tsx
+++ b/client/src/components/CurrencySwitcher.tsx
@@ -1,9 +1,17 @@
+import { useEffect } from "react";
 import { useCurrencyContext } from "@/context/CurrencyContext";
 
 export default function CurrencySwitcher() {
   const currencyCtx = useCurrencyContext();
   const currency = currencyCtx?.currency || 'ZAR';
   const changeCurrency = currencyCtx?.changeCurrency;
+
+  useEffect(() => {
+    const stored = typeof localStorage !== 'undefined' ? localStorage.getItem('currency') : null;
+    if (stored && stored !== currency) {
+      changeCurrency?.(stored);
+    }
+  }, []);
 
   const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     if (changeCurrency) {

--- a/client/src/hooks/useCurrency.ts
+++ b/client/src/hooks/useCurrency.ts
@@ -94,6 +94,13 @@ export function useCurrency() {
 
   async function changeCurrency(newCurrency: string) {
     const controller = new AbortController();
+    // Immediately update local state so UI reflects the new currency choice
+    setCurrency(newCurrency);
+    try {
+      localStorage.setItem('currency', newCurrency);
+    } catch {
+      /* ignore */
+    }
     setLoading(true);
     try {
       const res = await fetch(`https://api.exchangerate.host/latest?base=ZAR&symbols=${newCurrency}`, {
@@ -104,7 +111,6 @@ export function useCurrency() {
 
       const data = await res.json();
       if (data.rates && data.rates[newCurrency]) {
-        setCurrency(newCurrency);
         setRate(data.rates[newCurrency]);
         try {
           localStorage.setItem('currency', newCurrency);


### PR DESCRIPTION
## Summary
- update `changeCurrency` in `useCurrency` to set currency state right away
- read stored currency on mount in `CurrencySwitcher`

## Testing
- `npm install`
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6845efe7ec44832986d1bbbf963c018d