### PR TITLE
Add currency formatter helper

### DIFF
--- a/client/src/components/Hero.tsx
+++ b/client/src/components/Hero.tsx
@@ -4,6 +4,7 @@ import CountdownTimer from "./CountdownTimer";
 import VideoModal from "./VideoModal";
 import SpectacularLogo from "./SpectacularLogo";
 import { fadeInUp, staggerContainer } from "@/lib/animations";
+import { formatCurrency } from "@/lib/formatCurrency";
 import { useState, useEffect } from "react";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useCurrencyContext } from "@/context/CurrencyContext";
@@ -17,7 +18,6 @@ export default function Hero() {
   const currencyCtx = useCurrencyContext();
   const currency = currencyCtx?.currency || 'ZAR';
   const convert = currencyCtx?.convert || ((v: number) => v);
-  const getSymbol = currencyCtx?.getSymbol || ((c: string) => 'R');
   const loading = currencyCtx?.loading || false;
 
   useEffect(() => {
@@ -309,7 +309,7 @@ export default function Hero() {
                 >
                   <Rocket className="inline mr-3" size={24} />
                 </motion.div>
-                {`CLAIM YOUR LEGACY - ${loading ? '...' : `${getSymbol(currency)}${convert(249).toLocaleString(undefined, { maximumFractionDigits: 2 })}`}`}
+                {`CLAIM YOUR LEGACY - ${loading ? '...' : formatCurrency(convert(249), currency)}`}
               </motion.div>
             </motion.button>
             

--- a/client/src/components/Pricing.tsx
+++ b/client/src/components/Pricing.tsx
@@ -3,6 +3,7 @@ import { Check } from "lucide-react";
 import { fadeInUp, staggerContainer } from "@/lib/animations";
 import { useToast } from "@/hooks/use-toast";
 import { useCurrencyContext } from "@/context/CurrencyContext";
+import { formatCurrency } from "@/lib/formatCurrency";
 import CurrencySwitcher from "./CurrencySwitcher";
 
 export default function Pricing() {
@@ -10,7 +11,6 @@ export default function Pricing() {
   const currencyCtx = useCurrencyContext();
   const currency = currencyCtx?.currency || 'ZAR';
   const convert = currencyCtx?.convert || ((v: number) => v);
-  const getSymbol = currencyCtx?.getSymbol || ((c: string) => 'R');
   const loading = currencyCtx?.loading || false;
 
   // Prices in ZAR (base)
@@ -125,7 +125,7 @@ export default function Pricing() {
                 {/* Price */}
                 <div className="text-center pb-4 border-b border-gray-800/50">
                   <span className="text-5xl md:text-6xl font-bold text-white">
-                    {loading ? '...' : `${getSymbol?.(currency)}${convert?.(plan.priceZAR).toLocaleString(undefined, { maximumFractionDigits: 2 })}`}
+                    {loading ? '...' : formatCurrency(convert?.(plan.priceZAR), currency)}
                   </span>
                   <span className="text-gray-400 text-lg">{plan.period}</span>
                   <div className="mt-2 text-yellow-500 text-sm font-medium">

--- a/client/src/components/Registration.tsx
+++ b/client/src/components/Registration.tsx
@@ -28,6 +28,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { fadeInUp, staggerContainer, scaleIn, bounceIn } from "@/lib/animations";
 import { useCurrencyContext } from "@/context/CurrencyContext";
+import { formatCurrency } from "@/lib/formatCurrency";
 
 
 const registrationSchema = z.object({
@@ -54,7 +55,6 @@ export default function Registration() {
   const currencyCtx = useCurrencyContext();
   const currency = currencyCtx?.currency || 'ZAR';
   const convert = currencyCtx?.convert || ((v: number) => v);
-  const getSymbol = currencyCtx?.getSymbol || ((c: string) => 'R');
   const loading = currencyCtx?.loading || false;
   const [registrationType, setRegistrationType] = useState<"individual" | "group">("individual");
 
@@ -283,10 +283,10 @@ export default function Registration() {
               <div className="mb-6">
                 <div className="flex items-baseline space-x-2">
                   <span className="text-4xl font-bold gradient-text">
-                    {loading ? '...' : `${getSymbol(currency)}${convert(249).toLocaleString(undefined, { maximumFractionDigits: 2 })}`}
+                    {loading ? '...' : formatCurrency(convert(249), currency)}
                   </span>
                   <span className="text-gray-400 line-through">
-                    {loading ? '...' : `${getSymbol(currency)}${convert(399).toLocaleString(undefined, { maximumFractionDigits: 2 })}`}
+                    {loading ? '...' : formatCurrency(convert(399), currency)}
                   </span>
                 </div>
                 <p className="text-green-400 text-sm font-semibold">Save 38% - Limited Time</p>
@@ -370,10 +370,10 @@ export default function Registration() {
               <div className="mb-6">
                 <div className="flex items-baseline space-x-2">
                   <span className="text-4xl font-bold bg-gradient-to-r from-purple-500 to-blue-500 bg-clip-text text-transparent">
-                    {loading ? '...' : `${getSymbol(currency)}${convert(1000).toLocaleString(undefined, { maximumFractionDigits: 2 })}`}
+                    {loading ? '...' : formatCurrency(convert(1000), currency)}
                   </span>
                   <span className="text-gray-400 line-through">
-                    {loading ? '...' : `${getSymbol(currency)}${convert(1500).toLocaleString(undefined, { maximumFractionDigits: 2 })}`}
+                    {loading ? '...' : formatCurrency(convert(1500), currency)}
                   </span>
                 </div>
                 <p className="text-green-400 text-sm font-semibold">Save 33% - Early Bird</p>
@@ -726,7 +726,7 @@ export default function Registration() {
                             <Rocket className="w-6 h-6" />
                           </motion.div>
                           <span>
-                            {`Secure My VIP Seat - ${loading ? '...' : `${getSymbol(currency)}${convert(registrationType === 'individual' ? 249 : 1000).toLocaleString(undefined, { maximumFractionDigits: 2 })}`}`}
+                            {`Secure My VIP Seat - ${loading ? '...' : formatCurrency(convert(registrationType === 'individual' ? 249 : 1000), currency)}`}
                           </span>
                           <ArrowRight className="w-6 h-6" />
                         </>

--- a/client/src/lib/formatCurrency.ts
+++ b/client/src/lib/formatCurrency.ts
@@ -1,0 +1,4 @@
+export function formatCurrency(amount: number, currency: string = 'ZAR', locale: string | undefined = undefined) {
+  return new Intl.NumberFormat(locale, { style: 'currency', currency }).format(amount);
+}
+export default formatCurrency;

--- a/client/src/pages/BankPayment.tsx
+++ b/client/src/pages/BankPayment.tsx
@@ -7,13 +7,13 @@ import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { useToast } from "@/hooks/use-toast";
 import { useCurrencyContext } from "@/context/CurrencyContext";
+import { formatCurrency } from "@/lib/formatCurrency";
 
 export default function BankPayment() {
   const { toast } = useToast();
   const currencyCtx = useCurrencyContext();
   const currency = currencyCtx?.currency || 'ZAR';
   const convert = currencyCtx?.convert || ((v: number) => v);
-  const getSymbol = currencyCtx?.getSymbol || ((c: string) => 'R');
   const loading = currencyCtx?.loading || false;
 
   const [isProcessing, setIsProcessing] = useState(false);
@@ -106,7 +106,7 @@ export default function BankPayment() {
   };
 
   const formatPrice = (priceZAR: number) => {
-    return `${getSymbol(currency)}${convert(priceZAR).toLocaleString(undefined, { maximumFractionDigits: 2 })}`;
+    return formatCurrency(convert(priceZAR), currency);
   };
 
   const copyBankDetails = () => {
@@ -311,7 +311,7 @@ Thank you!`
                         : 'bg-black/20 text-yellow-400'
                     }`}
                   >
-                    {`Elite Access - ${loading ? '...' : `${getSymbol(currency)}${convert(planDetails.elite.priceZAR).toLocaleString(undefined, { maximumFractionDigits: 2 })}`}`}
+                    {`Elite Access - ${loading ? '...' : formatPrice(planDetails.elite.priceZAR)}`}
                   </Button>
                   <Button
                     type="button"
@@ -322,7 +322,7 @@ Thank you!`
                         : 'bg-black/20 text-purple-400'
                     }`}
                   >
-                    {`Premium Mastermind - ${loading ? '...' : `${getSymbol(currency)}${convert(planDetails.premium.priceZAR).toLocaleString(undefined, { maximumFractionDigits: 2 })}`}`}
+                    {`Premium Mastermind - ${loading ? '...' : formatPrice(planDetails.premium.priceZAR)}`}
                   </Button>
                 </div>
 


### PR DESCRIPTION
## Summary
- centralize currency formatting in a new helper
- use the helper in Pricing, Hero, BankPayment and Registration

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_6845efecc38883298a9288ff54ffb819